### PR TITLE
handle connection establish failures

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,8 +1,8 @@
 const { status } = require('./constants')
 
 module.exports = class WebSocketError extends Error {
-  constructor(msg, code, status, fn = WebSocketError) {
-    super(`${code}: ${msg}`)
+  constructor(msg, code, status, fn = WebSocketError, cause) {
+    super(`${code}: ${msg}`, { cause })
     this.code = code
     this.status = status
 
@@ -13,6 +13,16 @@ module.exports = class WebSocketError extends Error {
 
   get name() {
     return 'WebSocketError'
+  }
+
+  static NETWORK_ERROR(msg, cause) {
+    return new WebSocketError(
+      msg,
+      'NETWORK_ERROR',
+      0,
+      WebSocketError.NETWORK_ERROR,
+      cause
+    )
   }
 
   static NOT_CONNECTED(msg = 'Socket is not connected') {

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -271,8 +271,8 @@ const handshake = (exports.handshake = function handshake(req, cb) {
     cb(null)
   })
 
-  req.on('error', () => {
-    cb(errors.NOT_CONNECTED())
+  req.on('error', (err) => {
+    cb(errors.NETWORK_ERROR('Network error', err))
   })
 
   req.end()

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -234,6 +234,7 @@ module.exports = exports = class WebSocket extends Duplex {
   }
 
   _predestroy() {
+    if (!this._socket) return
     this._socket.destroy()
   }
 }
@@ -268,6 +269,10 @@ const handshake = (exports.handshake = function handshake(req, cb) {
     if (head.byteLength) socket.unshift(head)
 
     cb(null)
+  })
+
+  req.on('error', () => {
+    cb(errors.NOT_CONNECTED())
   })
 
   req.end()

--- a/test.js
+++ b/test.js
@@ -88,3 +88,11 @@ test('ping pong', async (t) => {
       .on('open', () => client.ping('hello'))
   })
 })
+
+test('connection refused', (t) => {
+  t.plan(1)
+
+  const client = new ws.Socket({ port: 8080 })
+
+  client.on('error', (err) => t.ok(err))
+})


### PR DESCRIPTION
Prior to this when attempting to connect to a server that is down, it would throw `Uncaught Error: network is unreachable` and was not possible to catch it.